### PR TITLE
Fix Ubuntu 22.04 postgres install issue

### DIFF
--- a/distros/ubuntu.go
+++ b/distros/ubuntu.go
@@ -450,7 +450,7 @@ func getUbuntuInstallPgClient(bc *c.CmdPkg, t string) error {
 // Ubuntu 22.04 install Postgres client Commands
 var u2204InstPgClient = []c.SingleCmd{
 	c.SingleCmd{
-		Cmd:        "DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-client-12",
+		Cmd:        "DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-client-14",
 		Errmsg:     "Unable to install PostgreSQL client",
 		Hard:       true,
 		Timeout:    0,


### PR DESCRIPTION
When I ran godojo on 22.04, I got an error saying `E: Unable to locate package postgresql-client-12`. On my machine, it lists `postgresql-client-14` as an option to install:
```
$ apt-cache search postgresql-client
postgresql-client - front-end programs for PostgreSQL (supported version)
postgresql-client-14 - front-end programs for PostgreSQL 14
postgresql-client-common - manager for multiple PostgreSQL client versions
```
This matches what's on https://packages.ubuntu.com/jammy/postgresql-client. I built the godojo binary from my fork with this change, and I was able to perform the install successfully.