### PR TITLE
Remove hard-coded references to /opt/dojo

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -350,11 +350,11 @@ func hane(d *DDConfig, s []string) error {
 			fmt.Sprintf("Unable to run command: %v", t[j]),
 			true)
 	}
-	d.traceMsg("Final change of ownership for /opt/dojo")
+	d.traceMsg("Final change of ownership for " + d.conf.Install.Root)
 	sendCmd(d,
 		tempLog,
-		"chown -R "+d.conf.Install.OS.User+":"+d.conf.Install.OS.Group+" /opt/dojo",
-		"Unable to set file ownership for /opt/dojo",
+		"chown -R "+d.conf.Install.OS.User+":"+d.conf.Install.OS.Group+" "+d.conf.Install.Root,
+		"Unable to set file ownership for "+d.conf.Install.Root,
 		false)
 
 	return nil

--- a/distros/rhel.go
+++ b/distros/rhel.go
@@ -632,7 +632,7 @@ var rhel8PrepDjango = []c.SingleCmd{
 		AfterText:  "",
 	},
 	c.SingleCmd{
-		Cmd:        "python3.9 -m virtualenv --python=/usr/bin/python3.9 /opt/dojo",
+		Cmd:        "python3.9 -m virtualenv --python=/usr/bin/python3.9 {conf.Install.Root}",
 		Errmsg:     "Unable to create virtualenv for DefectDojo",
 		Hard:       true,
 		Timeout:    0,
@@ -640,7 +640,7 @@ var rhel8PrepDjango = []c.SingleCmd{
 		AfterText:  "",
 	},
 	c.SingleCmd{
-		Cmd:        "/opt/dojo/bin/python3 -m pip install --upgrade pip",
+		Cmd:        "{conf.Install.Root}/bin/python3 -m pip install --upgrade pip",
 		Errmsg:     "Upgrade of Python pip failed",
 		Hard:       true,
 		Timeout:    0,
@@ -648,7 +648,7 @@ var rhel8PrepDjango = []c.SingleCmd{
 		AfterText:  "",
 	},
 	c.SingleCmd{
-		Cmd:        "/opt/dojo/bin/pip3 install -r /opt/dojo/django-DefectDojo/requirements.txt",
+		Cmd:        "{conf.Install.Root}/bin/pip3 install -r {conf.Install.Root}/django-DefectDojo/requirements.txt",
 		Errmsg:     "Unable to install Python3 modules for DefectDojo",
 		Hard:       true,
 		Timeout:    0,
@@ -741,7 +741,7 @@ var rhel8CreateSettings = []c.SingleCmd{
 	},
 	c.SingleCmd{
 		Cmd: "echo '# Add customizations here\n# For more details see:" +
-			" https://documentation.defectdojo.com/getting_started/configuration/' > /opt/dojo/customizations/local_settings.py",
+			" https://documentation.defectdojo.com/getting_started/configuration/' > {conf.Install.Root}/customizations/local_settings.py",
 		Errmsg:     "Unable to change ownership of .env.prod file",
 		Hard:       true,
 		Timeout:    0,
@@ -868,7 +868,7 @@ var rhel8SetupDojo = []c.SingleCmd{
 		AfterText:  "",
 	},
 	c.SingleCmd{
-		Cmd:        "cd /opt/dojo/django-DefectDojo && source ../bin/activate && python3 manage.py initialize_test_types",
+		Cmd:        "cd {conf.Install.Root}/django-DefectDojo && source ../bin/activate && python3 manage.py initialize_test_types",
 		Errmsg:     "Failed to initialize test_types",
 		Hard:       true,
 		Timeout:    0,
@@ -876,7 +876,7 @@ var rhel8SetupDojo = []c.SingleCmd{
 		AfterText:  "",
 	},
 	c.SingleCmd{
-		Cmd:        "cd /opt/dojo/django-DefectDojo && source ../bin/activate && python3 manage.py initialize_permissions",
+		Cmd:        "cd {conf.Install.Root}/django-DefectDojo && source ../bin/activate && python3 manage.py initialize_permissions",
 		Errmsg:     "Failed to initialize permissions",
 		Hard:       true,
 		Timeout:    0,

--- a/distros/template-os.tpl
+++ b/distros/template-os.tpl
@@ -729,7 +729,7 @@ var t2204CreateSettings = []c.SingleCmd{
 	},
 	c.SingleCmd{
 		Cmd: "echo '# Add customizations here\n# For more details see:" +
-			" https://documentation.defectdojo.com/getting_started/configuration/' > /opt/dojo/customizations/local_settings.py",
+			" https://documentation.defectdojo.com/getting_started/configuration/' > {conf.Install.Root}/customizations/local_settings.py",
 		Errmsg:     "Unable to change ownership of .env.prod file",
 		Hard:       true,
 		Timeout:    0,
@@ -856,7 +856,7 @@ var t2204SetupDojo = []c.SingleCmd{
 		AfterText:  "",
 	},
 	c.SingleCmd{
-		Cmd:        "cd /opt/dojo/django-DefectDojo && source ../bin/activate && python3 manage.py initialize_test_types",
+		Cmd:        "cd {conf.Install.Root}/django-DefectDojo && source ../bin/activate && python3 manage.py initialize_test_types",
 		Errmsg:     "Failed to initialize test_types",
 		Hard:       true,
 		Timeout:    0,
@@ -864,7 +864,7 @@ var t2204SetupDojo = []c.SingleCmd{
 		AfterText:  "",
 	},
 	c.SingleCmd{
-		Cmd:        "cd /opt/dojo/django-DefectDojo && source ../bin/activate && python3 manage.py initialize_permissions",
+		Cmd:        "cd {conf.Install.Root}/django-DefectDojo && source ../bin/activate && python3 manage.py initialize_permissions",
 		Errmsg:     "Failed to initialize permissions",
 		Hard:       true,
 		Timeout:    0,

--- a/distros/ubuntu.go
+++ b/distros/ubuntu.go
@@ -725,7 +725,7 @@ var u2204CreateSettings = []c.SingleCmd{
 	},
 	c.SingleCmd{
 		Cmd: "echo '# Add customizations here\n# For more details see:" +
-			" https://documentation.defectdojo.com/getting_started/configuration/' > /opt/dojo/customizations/local_settings.py",
+			" https://documentation.defectdojo.com/getting_started/configuration/' > {conf.Install.Root}/customizations/local_settings.py",
 		Errmsg:     "Unable to change ownership of .env.prod file",
 		Hard:       true,
 		Timeout:    0,
@@ -852,7 +852,7 @@ var u2204SetupDojo = []c.SingleCmd{
 		AfterText:  "",
 	},
 	c.SingleCmd{
-		Cmd:        "cd /opt/dojo/django-DefectDojo && source ../bin/activate && python3 manage.py initialize_test_types",
+		Cmd:        "cd {conf.Install.Root}/django-DefectDojo && source ../bin/activate && python3 manage.py initialize_test_types",
 		Errmsg:     "Failed to initialize test_types",
 		Hard:       true,
 		Timeout:    0,
@@ -860,7 +860,7 @@ var u2204SetupDojo = []c.SingleCmd{
 		AfterText:  "",
 	},
 	c.SingleCmd{
-		Cmd:        "cd /opt/dojo/django-DefectDojo && source ../bin/activate && python3 manage.py initialize_permissions",
+		Cmd:        "cd {conf.Install.Root}/django-DefectDojo && source ../bin/activate && python3 manage.py initialize_permissions",
 		Errmsg:     "Failed to initialize permissions",
 		Hard:       true,
 		Timeout:    0,


### PR DESCRIPTION
I attempted to install to a directory other than `/opt/dojo` and encountered some errors.