### PR TITLE
Update to handle Python 3.11.x being manually added

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o godojo

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -12,9 +12,9 @@ import (
 // dojoConfig.yml - example config file, used as default for dev installs
 // setup-superuser.expect - expect script to set the default admin password
 // factory_2.0.3 - python file to work around a bug in Python 3.8 and DefectDojo 1.15.1
-//                 see: https://github.com/DefectDojo/godojo/blob/master/ubuntu.go#L436
+// - see: https://github.com/DefectDojo/godojo/blob/master/ubuntu.go#L436
 // Next line is an example of a patch for a pre-2.0.0 version of DefectDojo
-//var factory2 = "embd/factory_2.0.3"
+// var factory2 = "embd/factory_2.0.3"
 // gdj.tar.gz - experiment on embedding commands into godojo, not currently used
 var embdConfig = "embd/dojoConfig.yml"
 var suExpect = "embd/setup-superuser.expect"
@@ -282,4 +282,5 @@ type optionalConfig struct {
 	Key        string `yaml:"Key"`
 	Tmpdir     string `yaml:"Tmpdir"`
 	UsrInst    bool   `yaml:"UsrInst"`
+	PyPath     string `yaml:"PyPath"`
 }

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -46,7 +46,7 @@ type DDConfig struct {
 
 // Set the godojo defaults in the DDConfig struct
 func (d *DDConfig) setGodojoDefaults() {
-	d.ver = "1.2.2"
+	d.ver = "1.2.3"
 	d.cf = "dojoConfig.yml"
 
 	// Setup default logging
@@ -74,6 +74,15 @@ func (d *DDConfig) setGodojoDefaults() {
 	d.modf = ".dd.mod"
 	d.tgzf = "gdj.tar.gz"
 
+	// Set the normal Python3 path
+	d.conf.Options.PyPath = "/usr/bin/python3"
+
+	// Use environment variable to override the deafult python binary path
+	newPath := os.Getenv("PYPATH")
+	if len(newPath) > 0 {
+		// PYPATH is set
+		d.conf.Options.PyPath = newPath
+	}
 }
 
 func (gd *DDConfig) prepLogging() io.Writer {
@@ -198,6 +207,7 @@ func (gd *DDConfig) getReplacements() map[string]string {
 	iv["{yarnGPG}"] = gd.conf.Options.YarnGPG                      // Yarn's GPG key URL
 	iv["{yarnRepo}"] = gd.conf.Options.YarnRepo                    // Yarn's package URL
 	iv["{nodeURL}"] = gd.conf.Options.NodeURL                      // Node's URL
+	iv["{PyPath}"] = gd.conf.Options.PyPath                        // Path to Python binary to use for virtualenv
 	iv["{conf.Install.Root}"] = gd.conf.Install.Root               // Path where DefectDojo is installed defaults to /opt/dojo
 	iv["{conf.Install.OS.Group}"] = gd.conf.Install.OS.Group       // OS group used by DefectDojo application
 	iv["{conf.Install.OS.User}"] = gd.conf.Install.OS.User         // OS user used by DefectDojo application

--- a/cmd/embd/dojoConfig.yml
+++ b/cmd/embd/dojoConfig.yml
@@ -14,8 +14,8 @@
 # SecretKey
 
 Install:
-  Version: "2.18.4" # DD_Version - Release version of DefectDojo from Github Releases
-  SourceInstall: true # DD_SourceInstall - Boolean if a source install is desired (vs a release)
+  Version: "2.32.2" # DD_Version - Release version of DefectDojo from Github Releases
+  SourceInstall: false # DD_SourceInstall - Boolean if a source install is desired (vs a release)
   # If ^ is true, a souce code install will occur overriding the release version provided
   SourceBranch: "master" # DD_SourceBranch - The branch's HEAD to be checked out if SourceInstall is true
   SourceCommit: # DD_SourceCommit - If there is a value here, the specific commit will be used over the branch ^
@@ -57,7 +57,7 @@ Install:
     Env: "/dojo/settings/.env.prod" # DD_SET_Env - Path to DefectDojo's environmental variables file
   Admin:
     User: "admin" # DD_ADMIN_User - Admin user for the DefectDojo web app
-    Pass: "ddadmin" # DD_ADMIN_Pass - Password for the DefectDojo web app admin user Note: set to 24 random characters
+    Pass: "P4ssword!" # DD_ADMIN_Pass - Password for the DefectDojo web app admin user Note: set to 24 random characters
     Email: "admin@localhost" # DD_ADMIN_Email - Email address for the web app admin user
     First: "Default" # DD_ADMIN_First - Web app admin users's first name
     Last: "Admin" # DD_ADMIN_Last - Web app admin users's last name

--- a/cmd/os.go
+++ b/cmd/os.go
@@ -91,6 +91,11 @@ func determineLinux(d *DDConfig, tOS *targetOS) {
 			tOS.distro = "rhel"
 			tOS.release = onlyMajorVer(tOS.release)
 			tOS.id = tOS.distro + ":" + tOS.release
+			// RHEL's latest Python is 3.9, so set this as Python path
+			// to keep functionality the same as before introducing the PyPath option
+			d.conf.Options.PyPath = "/usr/bin/python3.9"
+			// The above will work for RHEL 8 or 9 with DefectDojo v 2.31.0
+			// TODO Make this check for 3.11 to handle DD versions greater than 2.31.0
 			return
 		}
 		return

--- a/distros/rhel.go
+++ b/distros/rhel.go
@@ -632,7 +632,7 @@ var rhel8PrepDjango = []c.SingleCmd{
 		AfterText:  "",
 	},
 	c.SingleCmd{
-		Cmd:        "python3.9 -m virtualenv --python=/usr/bin/python3.9 {conf.Install.Root}",
+		Cmd:        "python3.9 -m virtualenv --python={PyPath} {conf.Install.Root}",
 		Errmsg:     "Unable to create virtualenv for DefectDojo",
 		Hard:       true,
 		Timeout:    0,
@@ -642,6 +642,14 @@ var rhel8PrepDjango = []c.SingleCmd{
 	c.SingleCmd{
 		Cmd:        "{conf.Install.Root}/bin/python3 -m pip install --upgrade pip",
 		Errmsg:     "Upgrade of Python pip failed",
+		Hard:       true,
+		Timeout:    0,
+		BeforeText: "",
+		AfterText:  "",
+	},
+	c.SingleCmd{
+		Cmd:        "{conf.Install.Root}/bin/pip3 install --upgrade setuptools",
+		Errmsg:     "",
 		Hard:       true,
 		Timeout:    0,
 		BeforeText: "",

--- a/distros/template-os.tpl
+++ b/distros/template-os.tpl
@@ -620,7 +620,7 @@ func getTemplatePrepDjango(bc *c.CmdPkg, t string) error {
 // Template 22.04 Prep Django Commands
 var t2204PrepDjango = []c.SingleCmd{
 	c.SingleCmd{
-		Cmd:        "python3 -m virtualenv --python=/usr/bin/python3 {conf.Install.Root}",
+		Cmd:        "python3 -m virtualenv --python={PyPath} {conf.Install.Root}",
 		Errmsg:     "Unable to setup virtualenv for DefectDojo",
 		Hard:       true,
 		Timeout:    0,
@@ -629,6 +629,14 @@ var t2204PrepDjango = []c.SingleCmd{
 	},
 	c.SingleCmd{
 		Cmd:        "{conf.Install.Root}/bin/python3 -m pip install --upgrade pip",
+		Errmsg:     "",
+		Hard:       true,
+		Timeout:    0,
+		BeforeText: "",
+		AfterText:  "",
+	},
+	c.SingleCmd{
+		Cmd:        "{conf.Install.Root}/bin/pip3 install --upgrade setuptools",
 		Errmsg:     "",
 		Hard:       true,
 		Timeout:    0,

--- a/distros/ubuntu.go
+++ b/distros/ubuntu.go
@@ -662,7 +662,7 @@ func getUbuntuPrepDjango(bc *c.CmdPkg, t string) error {
 // Ubuntu 22.04 Prep Django Commands
 var u2204PrepDjango = []c.SingleCmd{
 	c.SingleCmd{
-		Cmd:        "python3 -m virtualenv --python=/usr/bin/python3 {conf.Install.Root}",
+		Cmd:        "python3 -m virtualenv --python={PyPath} {conf.Install.Root}",
 		Errmsg:     "Unable to setup virtualenv for DefectDojo",
 		Hard:       true,
 		Timeout:    0,
@@ -671,6 +671,14 @@ var u2204PrepDjango = []c.SingleCmd{
 	},
 	c.SingleCmd{
 		Cmd:        "{conf.Install.Root}/bin/python3 -m pip install --upgrade pip",
+		Errmsg:     "",
+		Hard:       true,
+		Timeout:    0,
+		BeforeText: "",
+		AfterText:  "",
+	},
+	c.SingleCmd{
+		Cmd:        "{conf.Install.Root}/bin/pip3 install --upgrade setuptools",
 		Errmsg:     "",
 		Hard:       true,
 		Timeout:    0,


### PR DESCRIPTION
 to an existing distro that ships with an earlier version of Python.

An environment variable `PYPATH` can be passed to godojo to allow it to use that for the virutalenv rather than the system Python

e.g.
```
# PYPATH="/usr/local/bin/python3.11" ./godojo
```