### PR TITLE
Update for RHEL to use PYPATH for all actions since it ships with old…

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -74,11 +74,13 @@ func bootstrapInstall(d *DDConfig, t *targetOS) {
 
 // validPython checks to ensure the correct version of Python is available
 func validPython(d *DDConfig) {
-	d.sectionMsg("Checking for Python 3")
+	d.sectionMsg("Checking for Python 3.11")
 	if checkPythonVersion(d) {
-		d.statusMsg("Python 3 found, install can continue")
+		d.statusMsg("Python 3.11 found, install can continue")
 	} else {
-		d.errorMsg("Python 3 wasn't found, quitting installer")
+		d.errorMsg("Python 3.11 wasn't found, quitting installer\n" +
+			"         Please set PYPATH to a Python 3.11.x installation\n" +
+			"         And re-run godojo like: 'PYPATH=\"/path/to/python3.11\" ./godojo'")
 		os.Exit(1)
 	}
 }
@@ -88,12 +90,12 @@ func checkPythonVersion(d *DDConfig) bool {
 	// DefectDojo is now Python 3+, lets make sure that's installed
 	_, err := exec.LookPath("python3")
 	if err != nil {
-		d.errorMsg(fmt.Sprintf("Unable to find python binary. Error was: %+v", err))
+		d.errorMsg(fmt.Sprintf("Unable to find python binary in the path. Error was: %+v", err))
 		os.Exit(1)
 	}
 
 	// Execute the python3 command with --version to get the version
-	runCmd := exec.Command("python3", "--version")
+	runCmd := exec.Command(d.conf.Options.PyPath, "--version")
 
 	// Run command and gather its output
 	cmdOut, err := runCmd.CombinedOutput()
@@ -108,7 +110,7 @@ func checkPythonVersion(d *DDConfig) bool {
 	pyVer := line[1]
 
 	// Return true or false depending on Python version
-	return strings.HasPrefix(pyVer, "3.")
+	return strings.HasPrefix(pyVer, "3.11")
 }
 
 // downloadDojo takes a ponter to DDConfig and downloads a release or source

--- a/cmd/os.go
+++ b/cmd/os.go
@@ -84,6 +84,8 @@ func determineLinux(d *DDConfig, tOS *targetOS) {
 			tOS.distro = "rhel"
 			tOS.release = onlyMajorVer(tOS.release)
 			tOS.id = tOS.distro + ":" + tOS.release
+			// Check to make sure we're using a newer Python than the OS ships with
+			checkOldPythonForRHEL(d)
 			return
 		}
 		if strings.Contains(strings.ToLower(tOS.distro), "rhel") {
@@ -91,11 +93,8 @@ func determineLinux(d *DDConfig, tOS *targetOS) {
 			tOS.distro = "rhel"
 			tOS.release = onlyMajorVer(tOS.release)
 			tOS.id = tOS.distro + ":" + tOS.release
-			// RHEL's latest Python is 3.9, so set this as Python path
-			// to keep functionality the same as before introducing the PyPath option
-			d.conf.Options.PyPath = "/usr/bin/python3.9"
-			// The above will work for RHEL 8 or 9 with DefectDojo v 2.31.0
-			// TODO Make this check for 3.11 to handle DD versions greater than 2.31.0
+			// Check to make sure we're using a newer Python than the OS ships with
+			checkOldPythonForRHEL(d)
 			return
 		}
 		return
@@ -158,6 +157,23 @@ func determineLinux(d *DDConfig, tOS *targetOS) {
 	d.traceMsg("Unable to determine the linux distro, assuming unsupported.")
 	d.errorMsg("Unable to determine the Linux install target, quitting")
 	os.Exit(1)
+}
+
+func checkOldPythonForRHEL(d *DDConfig) {
+	d.traceMsg(fmt.Sprintf("Python path is %s\n", d.conf.Options.PyPath))
+	// RHEL 8's latest Python is 3.9
+	// Python 3.9 is too old for DB migrations so PyPath is must be set to install on RHEL 8
+	// If PyPath is set to Python 3.9, then error out
+	if strings.Compare(d.conf.Options.PyPath, "/usr/bin/python3.9") == 0 {
+		// For DD versions greater than 2.31.0, ENV variable PYPATH needs to be sent to an alternate install of Python
+		d.errorMsg("RHEL 8 requires setting PYPATH environmental variable to a Python 3.11.x installation\n" +
+			"         Either set an explicit path to a Python 3.11.x install or\n" +
+			"         Use update-alternatives / symlinks to have default Python be v3.11.x\n" +
+			"         godojo assumes the default Python is at /usr/bin/python3")
+		os.Exit(1)
+	}
+
+	return
 }
 
 func parseOSRelease(d *DDConfig, f string) (string, string, string) {

--- a/distros/rhel.go
+++ b/distros/rhel.go
@@ -624,7 +624,7 @@ func getRHELPrepDjango(bc *c.CmdPkg, t string) error {
 // RHEL 8 Prep Django Commands
 var rhel8PrepDjango = []c.SingleCmd{
 	c.SingleCmd{
-		Cmd:        "python3.9 -m pip install virtualenv",
+		Cmd:        "{PyPath} -m pip install virtualenv",
 		Errmsg:     "Unable to install virtualenv module for DefectDojo",
 		Hard:       true,
 		Timeout:    0,
@@ -632,7 +632,7 @@ var rhel8PrepDjango = []c.SingleCmd{
 		AfterText:  "",
 	},
 	c.SingleCmd{
-		Cmd:        "python3.9 -m virtualenv --python={PyPath} {conf.Install.Root}",
+		Cmd:        "{PyPath} -m virtualenv --python={PyPath} {conf.Install.Root}",
 		Errmsg:     "Unable to create virtualenv for DefectDojo",
 		Hard:       true,
 		Timeout:    0,


### PR DESCRIPTION
…er Python versions. RHEL 8 newest provided Python is 3.9 which is too old to install DefectDojo.